### PR TITLE
Add support for the ^SN (serial number) component

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ const zpl = label.generateZPL();
   - [Circle](#circle)
   - [Barcode](#barcode)
   - [Graphic](#graphic)
+  - [SerialNumber](#serialnumber)
   - [Raw](#Raw)
 - [Known Issues](#known-issues)
 - [Roadmap](#roadmap)
@@ -713,6 +714,40 @@ Displays an image on the label.
 Example of image:
 
 ![Graphic Image](./Images/example_image.png)
+
+#### Serial Number
+
+Serial Number displays incremental numbers on the label.
+
+##### Properties
+
+| Property | Type | Description |
+| :-- | :-- | :-- |
+| fontFamily | [FontFamily](#fontfamily) | Font family matrix to use |
+| horizontalAlignment | [Alignment](#alignment) | Horizontal alignment, default AlignmentValue.Start |
+| grid | [GridPosition](#gridposition) | Configure element placement within grid |
+| prependText | String | Sets the text that displays before the number |
+| startValue | String | Include any leading zeroes, default "1" |
+| increment | Number | The number to increment for each label, use negative to decrease, default 1 |
+| leadingZeroes | Boolean | If leading zeroes should be used, default false |
+| characterWidth | Number | Overrides the default character width, uses font family default if omitted |
+| characterHeight | Number | Overrides the default character height, uses font family default if omitted |
+
+Usage example:
+
+```js
+const serialNum = new SerialNumber();
+label.content.push(serialNum);
+serialNum.fontFamily = new FontFamily(FontFamilyName.D);
+serialNum.prependText = 'Label ';
+
+const zpl = label.generateZPL();
+// ^XA
+// ^FO10,10^AD,,,
+// ^FB780,1,0,L,0
+// ^SNLabel 1,1,N^FS
+// ^XZ
+```
 
 #### Raw
 

--- a/src/components/serial-number.js
+++ b/src/components/serial-number.js
@@ -1,0 +1,55 @@
+const BaseVisualComponent = require('./base-visual-component.js');
+const FontFamily = require('../properties/font-family.js');
+const Alignment = require('../properties/alignment.js');
+const FontFamilyName = require('../enums/font-family-name.js');
+const AlignmentValue = require('../enums/alignment-value.js');
+
+module.exports = class Text extends BaseVisualComponent {
+  constructor() {
+    super();
+
+    this.typeName = 'SerialNumber';
+    this.fontFamily = new FontFamily(FontFamilyName.A);
+    this.characterWidth = 0;
+    this.characterHeight = 0;
+    this.horizontalAlignment = new Alignment(AlignmentValue.Start);
+
+    this.prependText = '';
+    this.startValue = '1';
+    this.increment = 1;
+    this.leadingZeroes = false;
+  }
+
+  getTextLines() {
+    const expression = new RegExp('\\\\r\\\\n|\\\\n', 'g');
+    return this.prependText.replace(expression, '\n').split('\n');
+  }
+
+  generateZPL(offsetLeft, offsetTop, availableWidth, availableHeight, widthUnits, heightUnits) {
+    
+    const position = this.getPosition(offsetLeft, offsetTop, availableWidth, availableHeight, widthUnits, heightUnits);
+    let zpl = '';
+
+    let horizontalAlignment;
+    let lineSeparator = '';
+    switch ( this.horizontalAlignment.value ) {
+      case AlignmentValue.Start:
+        horizontalAlignment = 'L'
+        break;
+      case AlignmentValue.Center:
+        horizontalAlignment = 'C'
+        lineSeparator = '\\&'
+        break;
+      case AlignmentValue.End:
+        horizontalAlignment = 'R'
+        break;
+    }
+    
+    zpl += '^FO' + Math.round(position.left) + ',' + Math.round(position.top);
+    zpl += '^A' + this.fontFamily.value + ',' + (this.characterHeight || '') + ',' + (this.characterWidth || '') + ',' + '\n';
+    zpl += '^FB' + Math.round(position.width) + ',1,0,' + horizontalAlignment + ',0\n';
+
+    zpl += '^SN' + this.prependText + this.startValue + lineSeparator + ',' + this.increment + ',' + (( this.leadingZeroes )? 'Y': 'N' ) + '^FS\n';
+    return zpl;
+  }
+}

--- a/src/jszpl.js
+++ b/src/jszpl.js
@@ -12,6 +12,7 @@ const elements = {
   Grid: require('./components/grid.js'),
   Barcode: require('./components/barcode.js'),
   Raw: require('./components/raw.js'),
+  SerialNumber: require('./components/serial-number.js'),
 }
 
 module.exports = {
@@ -47,6 +48,7 @@ module.exports = {
   Graphic: elements.Graphic,
   Barcode: elements.Barcode,
   Raw: elements.Raw,
+  SerialNumber: elements.SerialNumber,
 
   elements: elements,
 }


### PR DESCRIPTION
Adds support for the SN (serial number) component in ZPL. Largely based off of the text component, this can be added to grids or labels